### PR TITLE
Fix chain generation logic and avoid overwriting existing DependsOn

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,21 +62,14 @@ class DependsOn {
         }
 
         const chains = this.getChains();
-        const chainLength = Math.floor(fnList.length / chains);
 
         // Generate dependsOn chain(s)
-        let count = 0;
-        for (let i = 0; i < fnList.length; i++) {
-            if (count === chainLength) {
-                count = 0;
-            }
+        for (let i = chains; i < fnList.length; i++) {
+            const parent = i - chains;
 
-            if (count > 0) {
-                fnList[i].dependsOn = fnList[i - 1].logicalId;
-                fnMap.set(fnList[i].name, fnList[i]);
-                this.serverless.cli.log(fnList[i].name + ' dependsOn ' + fnList[i - 1].name);
-            }
-            count++;
+            fnList[i].dependsOn = fnList[parent].logicalId;
+            fnMap.set(fnList[i].name, fnList[i]);
+            this.serverless.cli.log(fnList[i].name + ' dependsOn ' + fnList[parent].name);
         }
 
         // Update CloudFormation template

--- a/index.js
+++ b/index.js
@@ -88,7 +88,9 @@ class DependsOn {
                     const fnName = logicalToName.get(key);
                     const f = fnMap.get(fnName);
                     if (f.dependsOn) {
-                       resource.DependsOn = f.dependsOn;
+                       resource.DependsOn = (resource.DependsOn === undefined)
+                           ? f.dependsOn
+                           : [f.dependsOn].concat(resource.DependsOn);
                     }
                 }
             }


### PR DESCRIPTION
Hi,

This PR fixes two issues I found while using serverless-dependson-plugin:
- **Overwriting of existing DependsOn attributes**: I realized that, if a Lambda is depending on another one, the plugin will proceed to overwrite every existing DependsOn attribute I declared previously in the template with the logical Id of the Lambda on which it depends.
- **Imprecise chain generation logic**: I found that if I have 35 Lambdas to be deployed and I set the `chains` parameter to 10 I end up having actually 12 chains generated. This is due to a miscalculation on how the chains are built, potentially leading to errors in the deployment if one tries to stay as close as possible to the API rate limits enforced by AWS.

Moreover I took the liberty to simplify the code, eliminating two `Map`s (`fnMap` and `logicalToName`) that were IMHO quite superfluous.